### PR TITLE
Include BGR image type

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/rendering/ImageType.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/rendering/ImageType.java
@@ -52,6 +52,16 @@ public enum ImageType
             return BufferedImage.TYPE_INT_RGB;
         }
     },
+    
+    /** Blue, Green, Red */
+    BGR
+    {
+        @Override
+        int toBufferedImageType()
+        {
+            return BufferedImage.TYPE_3BYTE_BGR;
+        }
+    },
 
     /** Alpha, Red, Green, Blue */
     ARGB


### PR DESCRIPTION
JavaCV library and OpenCV assumes BGR layout for the pixels, creating this format in ImageType allows an easier integration with the BufferedImage generated by `PDFRenderer.renderImage` and JavaCV's `Java2DFrameUtils.toMat`, which handles the conversion to the class used by that library.